### PR TITLE
feat: get historical exchange rate data Issue25

### DIFF
--- a/backend/src/main/java/com/mauriexchange/code/dto/HistoricalRatePointDto.java
+++ b/backend/src/main/java/com/mauriexchange/code/dto/HistoricalRatePointDto.java
@@ -1,0 +1,16 @@
+package com.mauriexchange.code.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HistoricalRatePointDto {
+    private String date;
+    private Double officialRate;
+}
+

--- a/backend/src/main/java/com/mauriexchange/code/service/CurrencyService.java
+++ b/backend/src/main/java/com/mauriexchange/code/service/CurrencyService.java
@@ -5,6 +5,7 @@ import com.mauriexchange.code.dto.PaginatedResponseDto;
 import com.mauriexchange.code.dto.OfficialRateResponseDto;
 import com.mauriexchange.code.dto.LatestRatesResponseDto;
 import com.mauriexchange.code.dto.ConversionResponseDto;
+import com.mauriexchange.code.dto.HistoricalRatePointDto;
 
 import java.util.List;
 import java.util.Optional;
@@ -93,4 +94,9 @@ public interface CurrencyService {
      * If either currency is MRU, its rate is considered 1 by definition.
      */
     ConversionResponseDto convert(String from, String to, double amount);
+
+    /**
+     * Get historical official rates for a currency code within [start, end].
+     */
+    java.util.List<HistoricalRatePointDto> getHistoryByCodeAndRange(String code, String start, String end);
 }


### PR DESCRIPTION
Provide endpoint GET /api/v1/exchange-rates/history/{code}?start={date}&end={date} to return time-series data for charting historical trends.