### PR TITLE
feat: compare exchange rates between two dates Issue#26

### DIFF
--- a/backend/src/main/java/com/mauriexchange/code/dto/CompareRatesResponseDto.java
+++ b/backend/src/main/java/com/mauriexchange/code/dto/CompareRatesResponseDto.java
@@ -1,0 +1,20 @@
+package com.mauriexchange.code.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CompareRatesResponseDto {
+    private String code;
+    private String fromDate;
+    private String toDate;
+    private Double rateFrom;
+    private Double rateTo;
+    private String changePercent;
+}
+

--- a/backend/src/main/java/com/mauriexchange/code/service/CurrencyService.java
+++ b/backend/src/main/java/com/mauriexchange/code/service/CurrencyService.java
@@ -6,6 +6,7 @@ import com.mauriexchange.code.dto.OfficialRateResponseDto;
 import com.mauriexchange.code.dto.LatestRatesResponseDto;
 import com.mauriexchange.code.dto.ConversionResponseDto;
 import com.mauriexchange.code.dto.HistoricalRatePointDto;
+import com.mauriexchange.code.dto.CompareRatesResponseDto;
 
 import java.util.List;
 import java.util.Optional;
@@ -99,4 +100,9 @@ public interface CurrencyService {
      * Get historical official rates for a currency code within [start, end].
      */
     java.util.List<HistoricalRatePointDto> getHistoryByCodeAndRange(String code, String start, String end);
+
+    /**
+     * Compare two dates' official rates for a given currency.
+     */
+    CompareRatesResponseDto compareRates(String code, String fromDate, String toDate);
 }


### PR DESCRIPTION
Implement endpoint GET /api/v1/exchange-rates/compare?code={code}&from={date}&to={date} to compute rate difference and percentage change.